### PR TITLE
chore(usage): Use case on how to use simple_form-bulma

### DIFF
--- a/app/controllers/simple_form/bulma/items_controller.rb
+++ b/app/controllers/simple_form/bulma/items_controller.rb
@@ -1,0 +1,36 @@
+require_dependency 'simple_form/bulma/application_controller'
+
+module SimpleForm::Bulma
+  class ItemsController < ApplicationController
+    # GET /items
+    def index
+      @items = Item.all
+    end
+
+    # GET /items/new
+    def new
+      @item = Item.new
+    end
+
+    # POST /items
+    def create
+      @item = Item.new(item_params)
+
+      if @item.valid?
+        Item.all << @item
+        redirect_to @item, notice: 'Item was successfully created.'
+      else
+        render :new
+      end
+    end
+
+    private
+
+    def item_params
+      params.require(:item)
+            .permit(:name, :url, :secret_key, :active, :description, :background,
+                    :serial_number, :quantity, :published_at, :expired_at,
+                    :daily_check_at)
+    end
+  end
+end

--- a/app/models/simple_form/bulma/item.rb
+++ b/app/models/simple_form/bulma/item.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module SimpleForm::Bulma
+  class Item
+    include ActiveModel::Model
+    include ActiveModel::Attributes
+
+    attr_accessor :id, :name, :url, :secret_key, :description,
+                  :background, :serial_number, :quantity
+
+    attribute :active, :boolean, default: true
+    attribute :published_at, :datetime, default: -> { DateTime.current }
+    attribute :expired_at, :date
+    attribute :daily_check_at, :time
+
+    validates :name, :url, presence: true
+    validates :url, format: URI::DEFAULT_PARSER.make_regexp(%w[http https])
+
+    def self.all
+      @all ||= []
+    end
+  end
+end

--- a/app/views/layouts/simple_form/bulma/application.html.erb
+++ b/app/views/layouts/simple_form/bulma/application.html.erb
@@ -6,10 +6,11 @@
   <%= csp_meta_tag %>
 
   <%= stylesheet_link_tag    "simple_form/bulma/application", media: "all" %>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@1.0.0/css/bulma.min.css">
 </head>
 <body>
-
-<%= yield %>
-
+  <div class="container is-widescreen is-fullhd">
+    <%= yield %>
+  </div>
 </body>
 </html>

--- a/app/views/simple_form/bulma/items/_form.html.erb
+++ b/app/views/simple_form/bulma/items/_form.html.erb
@@ -1,0 +1,15 @@
+<%= simple_form_for(item) do |f| %>
+  <%= f.input :name %>
+  <%= f.input :url, placeholder: "URL should start with http or https" %>
+  <%= f.input :secret_key, as: :password %>
+  <%= f.input :active, as: :boolean %>
+  <%= f.input :description, as: :text %>
+  <%= f.input :background, as: :color %>
+  <%= f.input :serial_number, as: :integer %>
+  <%= f.input :quantity, as: :decimal %>
+  <%= f.input :published_at, as: :datetime, html5: true %>
+  <%= f.input :expired_at, as: :date, html5: true %>
+  <%= f.input :daily_check_at, as: :time, html5: true %>
+
+  <%= f.button :submit %>
+<% end %>

--- a/app/views/simple_form/bulma/items/index.html.erb
+++ b/app/views/simple_form/bulma/items/index.html.erb
@@ -1,0 +1,25 @@
+<p id="notice"><%= notice %></p>
+
+<h1>Items</h1>
+
+<%= link_to 'New Item', new_item_path %>
+
+<table>
+  <thead>
+    <tr>
+      <th>Name</th>
+      <th>Active</th>
+      <th>URL</th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <% @items.each do |item| %>
+      <tr>
+        <td><%= item.name %></td>
+        <td><%= item.active ? "true" : "false" %></td>
+        <td><%= item.url %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/simple_form/bulma/items/new.html.erb
+++ b/app/views/simple_form/bulma/items/new.html.erb
@@ -1,0 +1,5 @@
+<h1>New Item</h1>
+
+<%= render 'form', item: @item %>
+
+<%= link_to 'Back', items_path %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,2 +1,7 @@
+# frozen_string_literal: true
+
 SimpleForm::Bulma::Engine.routes.draw do
+  resources :items, only: %i[index new create]
+
+  root to: 'items#index'
 end

--- a/test/controllers/simple_form/bulma/items_controller_test.rb
+++ b/test/controllers/simple_form/bulma/items_controller_test.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module SimpleForm::Bulma
+  class ItemsControllerTest < ActionDispatch::IntegrationTest
+    include Engine.routes.url_helpers
+
+    test 'should get index' do
+      Item.all << Item.new(id: 1, name: 'Example', url: 'http://example.com')
+      get items_url
+      assert_response :success
+    end
+
+    test 'should get new' do
+      get new_item_url
+      assert_response :success
+    end
+  end
+end

--- a/test/fixtures/simple_form/bulma/items.yml
+++ b/test/fixtures/simple_form/bulma/items.yml
@@ -1,0 +1,19 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  name: MyString
+  url: https://one.com
+  description: MyText
+  background: "#000000"
+  serial_number: 1111
+  quantity: 10
+  published_at: 2024-06-15 22:21:16
+
+two:
+  name: MyString
+  url: https://two.com
+  description: MyText
+  background: "#ffffff"
+  serial_number: 2222
+  quantity: 20
+  published_at: 2024-06-15 22:21:16

--- a/test/models/simple_form/bulma/item_test.rb
+++ b/test/models/simple_form/bulma/item_test.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module SimpleForm::Bulma
+  class ItemTest < ActiveSupport::TestCase
+    test 'should not save item without name' do
+      item = SimpleForm::Bulma::Item.new(url: 'http://example.com')
+      assert_not item.valid?
+    end
+
+    test 'should not save item without url' do
+      item = SimpleForm::Bulma::Item.new(name: 'Example')
+      assert_not item.valid?
+    end
+
+    test 'should not save item without url format' do
+      item = SimpleForm::Bulma::Item.new(url: 'example.com', name: 'Example')
+      assert_not item.valid?
+    end
+  end
+end

--- a/test/simple_form/bulma_test.rb
+++ b/test/simple_form/bulma_test.rb
@@ -1,7 +1,9 @@
-require "test_helper"
+# frozen_string_literal: true
+
+require 'test_helper'
 
 class SimpleForm::BulmaTest < ActiveSupport::TestCase
-  test "it has a version number" do
+  test 'it has a version number' do
     assert SimpleForm::Bulma::VERSION
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,16 +1,17 @@
+# frozen_string_literal: true
+
 # Configure Rails Environment
-ENV["RAILS_ENV"] = "test"
+ENV['RAILS_ENV'] ||= 'test'
 
-require_relative "../test/dummy/config/environment"
-ActiveRecord::Migrator.migrations_paths = [File.expand_path("../test/dummy/db/migrate", __dir__)]
+require_relative '../test/dummy/config/environment'
+ActiveRecord::Migrator.migrations_paths = [File.expand_path('../test/dummy/db/migrate', __dir__)]
 ActiveRecord::Migrator.migrations_paths << File.expand_path('../db/migrate', __dir__)
-require "rails/test_help"
-
+# require 'rails/test_help'
 
 # Load fixtures from the engine
 if ActiveSupport::TestCase.respond_to?(:fixture_path=)
-  ActiveSupport::TestCase.fixture_path = File.expand_path("fixtures", __dir__)
+  ActiveSupport::TestCase.fixture_path = File.expand_path('fixtures', __dir__)
   ActionDispatch::IntegrationTest.fixture_path = ActiveSupport::TestCase.fixture_path
-  ActiveSupport::TestCase.file_fixture_path = ActiveSupport::TestCase.fixture_path + "/files"
+  ActiveSupport::TestCase.file_fixture_path = "#{ActiveSupport::TestCase.fixture_path}/files"
   ActiveSupport::TestCase.fixtures :all
 end


### PR DESCRIPTION
Example using a model with different types of inputs

```ruby
<%= simple_form_for(item) do |f| %>
  <%= f.input :name %>
  <%= f.input :url, placeholder: "URL should start with http or https" %>
  <%= f.input :secret_key, as: :password %>
  <%= f.input :active, as: :boolean %>
  <%= f.input :description, as: :text %>
  <%= f.input :background, as: :color %>
  <%= f.input :serial_number, as: :integer %>
  <%= f.input :quantity, as: :decimal %>
  <%= f.input :published_at, as: :datetime, html5: true %>
  <%= f.input :expired_at, as: :date, html5: true %>
  <%= f.input :daily_check_at, as: :time, html5: true %>
  <%= f.button :submit %>
<% end %>
```

Resources:
 https://api.rubyonrails.org/classes/ActiveModel/Model.html

![Peek 2024-06-16 01-52](https://github.com/JuanVqz/simple_form-bulma/assets/7331511/73bb9c47-d69d-43f6-a72d-8614a75ac48f)
